### PR TITLE
Here's my plan to add standard headers and fix navigation overlap:

### DIFF
--- a/cathode_rays_and_cathode_ray_tubes3.html
+++ b/cathode_rays_and_cathode_ray_tubes3.html
@@ -109,9 +109,16 @@
             display: none;
         }
     </style>
+    <style>
+        @media (min-width: 768px) {
+          .custom-page-header {
+            margin-left: 16rem; /* Assuming sidebar is w-64 (16rem) */
+          }
+        }
+    </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
-<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc;">
+<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc; position: relative; z-index: 100;" class="custom-page-header">
     <h3>cathode rays and cathode ray tube</h3>
     <audio controls src="cathode_rays_and_cathode_ray_tubes.mp3">
         Your browser does not support the audio element.

--- a/electronics.html
+++ b/electronics.html
@@ -162,9 +162,26 @@
             border-left: 4px solid #D1D5DB; 
             border-radius: 4px;
         }
+        @media (min-width: 768px) {
+          .custom-page-header {
+            margin-left: 16rem; /* Assuming sidebar is w-64 (16rem) */
+          }
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
+<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc; position: relative; z-index: 100;" class="custom-page-header">
+    <div style="max-width: 1200px; margin-left: auto; margin-right: auto; padding-left: 1rem; padding-right: 1rem; display: flex; flex-direction: column; align-items: center;">
+        <h3 style="font-size: 1.5em; margin-bottom: 10px;">Electronics</h3>
+        <audio controls src="electronics.mp3" style="margin-bottom: 10px;">
+            Your browser does not support the audio element.
+        </audio>
+        <nav style="margin-top: 10px; display: flex; flex-wrap: wrap; justify-content: center; gap: 10px;">
+            <a href="radioactivity.html" style="margin-right: 10px;">Previous Topic</a>
+            <a href="dashboard.html" style="margin-right: 10px;">Back to Dashboard</a>
+        </nav>
+    </div>
+</header>
 
     <div id="sidebar" class="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-6 transform -translate-x-full md:translate-x-0 transition-transform duration-300 ease-in-out z-50 shadow-lg flex flex-col">
         <h1 class="text-2xl font-bold mb-6 border-b border-gray-700 pb-3 flex-shrink-0">Electronics Guide</h1>

--- a/photoelectric_effect.html
+++ b/photoelectric_effect.html
@@ -147,10 +147,15 @@
             border-left: 4px solid #D1D5DB; /* gray-300 */
             border-radius: 4px;
         }
+        @media (min-width: 768px) {
+          .custom-page-header {
+            margin-left: 16rem; /* Assuming sidebar is w-64 (16rem) */
+          }
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
-<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc;">
+<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc; position: relative; z-index: 100;" class="custom-page-header">
     <h3>photoelectric effect</h3>
     <audio controls src="photoelectric_effect.mp3">
         Your browser does not support the audio element.

--- a/radioactivity.html
+++ b/radioactivity.html
@@ -162,9 +162,27 @@
             border-left: 4px solid #D1D5DB; /* gray-300 */
             border-radius: 4px;
         }
+        @media (min-width: 768px) {
+          .custom-page-header {
+            margin-left: 16rem; /* Assuming sidebar is w-64 (16rem) */
+          }
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
+<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc; position: relative; z-index: 100;" class="custom-page-header">
+    <div style="max-width: 1200px; margin-left: auto; margin-right: auto; padding-left: 1rem; padding-right: 1rem; display: flex; flex-direction: column; align-items: center;">
+        <h3 style="font-size: 1.5em; margin-bottom: 10px;">Radioactivity</h3>
+        <audio controls src="radioactivity.mp3" style="margin-bottom: 10px;">
+            Your browser does not support the audio element.
+        </audio>
+        <nav style="margin-top: 10px; display: flex; flex-wrap: wrap; justify-content: center; gap: 10px;">
+            <a href="photoelectric_effect.html" style="margin-right: 10px;">Previous Topic</a>
+            <a href="dashboard.html" style="margin-right: 10px;">Back to Dashboard</a>
+            <a href="electronics.html">Next Topic</a>
+        </nav>
+    </div>
+</header>
 
     <div id="sidebar" class="fixed top-0 left-0 h-full w-64 bg-gray-800 text-white p-6 transform -translate-x-full md:translate-x-0 transition-transform duration-300 ease-in-out z-50 shadow-lg flex flex-col">
         <h1 class="text-2xl font-bold mb-6 border-b border-gray-700 pb-3 flex-shrink-0">Radioactivity Guide</h1>

--- a/xrays.html
+++ b/xrays.html
@@ -137,10 +137,15 @@
             border-radius: 3px;
             font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         }
+        @media (min-width: 768px) {
+          .custom-page-header {
+            margin-left: 16rem; /* Assuming sidebar is w-64 (16rem) */
+          }
+        }
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
-<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc;">
+<header style="padding: 10px; background-color: #f0f0f0; margin-bottom: 20px; border-bottom: 1px solid #ccc; position: relative; z-index: 100;" class="custom-page-header">
     <h3>x-rays</h3>
     <audio controls src="x-rays.mp3">
         Your browser does not support the audio element.


### PR DESCRIPTION
- I'll add a standard header (including title, audio player, and navigation) to `radioactivity.html` and `electronics.html`.
- I'll ensure the previous/next topic links are correct for all pages.
- I'll omit the 'Next Topic' link on `electronics.html` since it's the last topic.
- I'll apply a CSS fix to the headers on relevant pages (cathode rays, xrays, photoelectric effect, radioactivity, electronics) to prevent the navigation buttons from being obscured by the sidebar. This involves adding a class to the header and a CSS rule for a left margin on medium and larger screens.
- Finally, I'll verify all navigation links and audio player sources across the 11 topic pages.